### PR TITLE
feat: Implement and display dungeon levels

### DIFF
--- a/src/game_engine.py
+++ b/src/game_engine.py
@@ -44,6 +44,7 @@ class GameEngine:
 
     def render(self):
         self.game_state.ui_manager.display_map(self.game_state.game_map, self.game_state.player)
-        self.game_state.ui_manager.display_player_stats(self.game_state.player)
+        # Pass game_state to display_player_stats
+        self.game_state.ui_manager.display_player_stats(self.game_state.player, self.game_state)
         if self.game_state.logger:
             self.game_state.ui_manager.display_log(self.game_state.logger.get_messages())

--- a/src/game_state.py
+++ b/src/game_state.py
@@ -15,6 +15,7 @@ class GameState:
         self.is_running = True
         self.step_count = 0
         self.on_special_tile = False
+        self.dungeon_level = 1  # Initialize dungeon level
 
     def to_dict(self):
         return {
@@ -24,6 +25,7 @@ class GameState:
             "is_running": self.is_running,
             "step_count": self.step_count,
             "on_special_tile": self.on_special_tile,
+            "dungeon_level": self.dungeon_level,  # Add dungeon_level to dictionary
             "log": self.logger.get_messages() if self.logger else []
         }
 
@@ -39,6 +41,7 @@ class GameState:
         game_state.is_running = data.get("is_running", True)
         game_state.step_count = data.get("step_count", 0)
         game_state.on_special_tile = data.get("on_special_tile", False)
+        game_state.dungeon_level = data.get("dungeon_level", 1)  # Load dungeon_level, default to 1
         if logger and "log" in data:
             for msg in data["log"]:
                 logger.add_message(msg)

--- a/src/interaction_manager.py
+++ b/src/interaction_manager.py
@@ -21,6 +21,9 @@ class InteractionManager:
         self.game_state.game_map = Map(self.game_state.game_map.width, self.game_state.game_map.height, map_type=map_type, entry_direction=entry_direction, game_state=self.game_state)
 
     def _handle_next_map_tile(self):
+        if self.game_state.game_map.current_map_type == "dungeon":
+            self.game_state.dungeon_level += 1
+            self.game_state.logger.add_message(f"Descending to Dungeon Level {self.game_state.dungeon_level}...")
         self._transition_map("Generating new dungeon map...", "dungeon")
 
     def _handle_north_exit_tile(self):

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -25,8 +25,11 @@ class UIManager:
                     row_str += tile_char
             print(row_str)
 
-    def display_player_stats(self, player):
-        print(f"Health: {player.health}/{player.max_health} Attack: {player.attack} Defense: {player.defense})")
+    def display_player_stats(self, player, game_state):
+        stats_string = f"Health: {player.health}/{player.max_health} Attack: {player.attack} Defense: {player.defense}"
+        if game_state and game_state.game_map and game_state.game_map.current_map_type == "dungeon":
+            stats_string += f" Dungeon Level: {game_state.dungeon_level}"
+        print(stats_string)
 
     def display_log(self, messages):
         print("\n--- Log ---")


### PR DESCRIPTION
- Added `dungeon_level` to `GameState`, defaulting to 1.
- Modified `UIManager` to display the current dungeon level next to player stats when the player is in a dungeon map.
- Updated `InteractionManager` to increment `dungeon_level` when the player transitions to a new map using a `NextMapTile` within a dungeon.
- Ensured `dungeon_level` is saved and loaded with the game state.